### PR TITLE
docs: rebrand LambdaTest to TestMu AI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,159 +1,115 @@
-# TestMu AI SmartUI: Puppeteer Samples with SDK & TestMu AI Hooks — TestMu AI (Formerly LambdaTest)
+# Run SmartUI Visual Tests with Puppeteer on TestMu AI (Formerly LambdaTest)
 
-Welcome to the TestMu AI SmartUI Puppeteer samples repository. This guide provides detailed instructions on integrating Puppeteer with TestMu AI for automated, cloud-based testing, including visual regression testing using SmartUI. Discover how to leverage the power of Puppeteer alongside TestMu AI's extensive testing capabilities to ensure your web applications look and perform their best across a wide range of devices and browsers.
+<p align="center">
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://www.npmjs.com/package/puppeteer"><img src="https://img.shields.io/npm/v/puppeteer.svg?style=for-the-badge&labelColor=000000" alt="Puppeteer version"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
+</p>
 
 ## Getting Started
 
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
+
+With TestMu AI (Formerly LambdaTest), you can run SmartUI visual regression tests with Puppeteer on real browsers. This sample shows how to configure Puppeteer + SmartUI to run on the TestMu AI cloud.
+
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
+
 ### Prerequisites
 
-Before you begin, ensure you have the following:
-- An active TestMu AI account. [Sign up here](https://www.testmuai.com/) if you don't have one.
-- Your TestMu AI Username and Access Key, available in your TestMu AI profile.
+- Node.js and npm (latest stable)
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
 
-### Initial Setup
+### Setup
 
-Clone this repository to get started with SmartUI tests using Puppeteer:
-
-```bash
-git clone https://github.com/LambdaTest/smartui-puppeteer-sample.git
-cd smartui-puppeteer-sample
-```
-
-Configure your environment with your TestMu AI credentials:
+Clone and install dependencies:
 
 ```bash
-export LT_USERNAME="Your LambdaTest Username"
-export LT_ACCESS_KEY="Your LambdaTest Access Key"
-```
-### Settings up SmartUI project
-
-You, need to create a `SmartUI` project at [TestMu AI - SmartUI Web App](https://smartui.lambdatest.com/projects). Now, you need to follow the steps below: 
-1. Click on the `New Project` button on the top right of the webpage.
-2. Select your `Platform type` as `SDK` for running `SDK` sample test below, else you can select `Platform type` as `Web` for running `hooks` sample.
-3. Provide name of your choice for the project.
-4. Now, add `Approvers` who are required to review the changes and approve/reject the results of the tests.
-5. (Optional) You can add `tags` of your choice such as `uat`, `dev` etc..
-6. Click on the `Get Started` button for completing the project creation.
-7. Now, select `NodeJS` setup guide and in the `Step 2` you can find the project token.
-
-### Setting up Project token: 
-Once, you have successfully setup the project for the `SmartUI` and copiec the `Project Token` from the `SmartUI Web App`: 
-
-```bash
-export PROJECT_TOKEN="<Your Copied Project Token to be pasted here>" 
-```
-
-## Testing with TestMu AI SDK
-
-### Overview
-
-Our sample tests demonstrate navigating to the TestMu AI homepage to verify the page title and conducting a full-page screenshot for visual regression testing.
-
-#### Setup
-
-Navigate to the SDK sample directory and install dependencies:
-
-```bash
-cd sdk
+git clone https://github.com/LambdaTest/smartui-puppeteer-sample && cd smartui-puppeteer-sample
 npm install
 ```
 
-#### Using SmartUI with Puppeteer
+Set your credentials as environment variables.
 
-TestMu AI's SmartUI SDK enhances your testing with automated visual regression capabilities. Here's how to capture a full-page screenshot:
-
-```javascript
-const { smartuiSnapshot } = require('@lambdatest/puppeteer-driver');
-
-await smartuiSnapshot(page, "Your_Screenshot_Name");
-```
-
-Replace `"Your_Screenshot_Name"` with a meaningful identifier. Screenshots are stored in TestMu AI for seamless UI comparison over time.
-
-### Execution
-
-Execute tests locally or on the TestMu AI Automation Cloud grid:
-
-- For local execution:
-  ```bash
-  npm run smartui-local
-  ```
-
-- For execution on TestMu AI Automation Cloud:
-  ```bash
-  npm run smartui-cloud
-  ```
-
-Visit our [documentation](https://www.testmuai.com/support/docs/smartui-puppeteer-sdk/) for comprehensive SDK guides and tutorials.
-
-## Testing with TestMu AI Hooks
-
-### Overview
-
-Like the SDK samples, these tests navigate to the TestMu AI homepage for title verification and visual regression via screenshot.
-
-#### Setup
-
-Access the Hooks sample directory and prepare your environment:
+**macOS / Linux:**
 
 ```bash
-cd hooks
-npm install
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+export LT_TUNNEL="YOUR_TUNNEL_NAME"
+export PROJECT_TOKEN="YOUR_PROJECT_TOKEN"
 ```
 
-#### Leveraging SmartUI Webhooks
-
-Use TestMu AI's webhook for seamless visual regression testing. Capture a screenshot with:
-
-```javascript
-await page.evaluate(() => {
-  // Replace "Your_Screenshot_Name" with the screenshot identifier
-  const screenshotName = "Your_Screenshot_Name";
-  const lambdatestAction = JSON.stringify({
-    action: 'smartui.takeScreenshot',
-    arguments: { fullPage: true, screenshotName }
-  });
-  // Execute the SmartUI action
-});
-```
-
-### Running the Tests
-
-Deploy your tests on the TestMu AI Automation grid with:
+**Windows:**
 
 ```bash
-npm run single
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+set LT_TUNNEL="YOUR_TUNNEL_NAME"
+set PROJECT_TOKEN="YOUR_PROJECT_TOKEN"
 ```
 
-## Support and Assistance
+### Run tests
 
-Our dedicated support team is available 24/7 to assist with any questions or challenges you may encounter. Contact us anytime at [support@testmuai.com](mailto:support@testmuai.com) for prompt and friendly support.
+```bash
+npm test
+```
 
-## 🚀 LambdaTest is Now TestMu AI
+View results on your TestMu AI dashboard.
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+### Local testing with TestMu AI Tunnel
 
-Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
 
-### 🔄 Our Rebrand Journey
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
 
-In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+Add the following to your capabilities:
 
-As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+```js
+tunnel: true,
+```
 
-Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
+## Contributions
 
-We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Node.js version, OS, and Puppeteer version.
 
-👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+## TestMu AI (Formerly LambdaTest) Community
 
-### 🔭 Explore TestMu AI
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
 
-The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-- [KaneAI](https://www.testmuai.com/kane-ai/)
-- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
-- [HyperExecute](https://www.testmuai.com/hyperexecute/)
-- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
-- [Pricing](https://www.testmuai.com/pricing/)
-- [Documentation](https://www.testmuai.com/support/docs/)
+## Learning Resources by TestMu AI (Formerly LambdaTest)
+
+Learn modern testing through tutorials, guides, videos, and weekly updates:
+
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
+
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
+
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
+
+ð Find the new home for [LambdaTest](https://www.testmuai.com).
+
+### How LambdaTest Evolved into TestMu AI
+
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
+
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
+
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
+
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
+
+## Support
+
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.

--- a/README.md
+++ b/README.md
@@ -135,13 +135,19 @@ Our dedicated support team is available 24/7 to assist with any questions or cha
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-**🔄 Our Rebrand Journey**
+### 🔄 Our Rebrand Journey
+
+In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+
+As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+
+Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 
-**🔭 Explore TestMu AI**
+### 🔭 Explore TestMu AI
 
 The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# LambdaTest SmartUI: Puppeteer Samples with SDK & LambdaTest Hooks
+# TestMu AI SmartUI: Puppeteer Samples with SDK & TestMu AI Hooks — TestMu AI (Formerly LambdaTest)
 
-Welcome to the LambdaTest SmartUI Puppeteer samples repository. This guide provides detailed instructions on integrating Puppeteer with LambdaTest for automated, cloud-based testing, including visual regression testing using SmartUI. Discover how to leverage the power of Puppeteer alongside LambdaTest's extensive testing capabilities to ensure your web applications look and perform their best across a wide range of devices and browsers.
+Welcome to the TestMu AI SmartUI Puppeteer samples repository. This guide provides detailed instructions on integrating Puppeteer with TestMu AI for automated, cloud-based testing, including visual regression testing using SmartUI. Discover how to leverage the power of Puppeteer alongside TestMu AI's extensive testing capabilities to ensure your web applications look and perform their best across a wide range of devices and browsers.
 
 ## Getting Started
 
 ### Prerequisites
 
 Before you begin, ensure you have the following:
-- An active LambdaTest account. [Sign up here](https://www.lambdatest.com/) if you don't have one.
-- Your LambdaTest Username and Access Key, available in your LambdaTest profile.
+- An active TestMu AI account. [Sign up here](https://www.testmuai.com/) if you don't have one.
+- Your TestMu AI Username and Access Key, available in your TestMu AI profile.
 
 ### Initial Setup
 
@@ -19,7 +19,7 @@ git clone https://github.com/LambdaTest/smartui-puppeteer-sample.git
 cd smartui-puppeteer-sample
 ```
 
-Configure your environment with your LambdaTest credentials:
+Configure your environment with your TestMu AI credentials:
 
 ```bash
 export LT_USERNAME="Your LambdaTest Username"
@@ -27,7 +27,7 @@ export LT_ACCESS_KEY="Your LambdaTest Access Key"
 ```
 ### Settings up SmartUI project
 
-You, need to create a `SmartUI` project at [Lambdatest - SmartUI Web App](https://smartui.lambdatest.com/projects). Now, you need to follow the steps below: 
+You, need to create a `SmartUI` project at [TestMu AI - SmartUI Web App](https://smartui.lambdatest.com/projects). Now, you need to follow the steps below: 
 1. Click on the `New Project` button on the top right of the webpage.
 2. Select your `Platform type` as `SDK` for running `SDK` sample test below, else you can select `Platform type` as `Web` for running `hooks` sample.
 3. Provide name of your choice for the project.
@@ -43,11 +43,11 @@ Once, you have successfully setup the project for the `SmartUI` and copiec the `
 export PROJECT_TOKEN="<Your Copied Project Token to be pasted here>" 
 ```
 
-## Testing with LambdaTest SDK
+## Testing with TestMu AI SDK
 
 ### Overview
 
-Our sample tests demonstrate navigating to the LambdaTest homepage to verify the page title and conducting a full-page screenshot for visual regression testing.
+Our sample tests demonstrate navigating to the TestMu AI homepage to verify the page title and conducting a full-page screenshot for visual regression testing.
 
 #### Setup
 
@@ -60,7 +60,7 @@ npm install
 
 #### Using SmartUI with Puppeteer
 
-LambdaTest's SmartUI SDK enhances your testing with automated visual regression capabilities. Here's how to capture a full-page screenshot:
+TestMu AI's SmartUI SDK enhances your testing with automated visual regression capabilities. Here's how to capture a full-page screenshot:
 
 ```javascript
 const { smartuiSnapshot } = require('@lambdatest/puppeteer-driver');
@@ -68,29 +68,29 @@ const { smartuiSnapshot } = require('@lambdatest/puppeteer-driver');
 await smartuiSnapshot(page, "Your_Screenshot_Name");
 ```
 
-Replace `"Your_Screenshot_Name"` with a meaningful identifier. Screenshots are stored in LambdaTest for seamless UI comparison over time.
+Replace `"Your_Screenshot_Name"` with a meaningful identifier. Screenshots are stored in TestMu AI for seamless UI comparison over time.
 
 ### Execution
 
-Execute tests locally or on the LambdaTest Automation Cloud grid:
+Execute tests locally or on the TestMu AI Automation Cloud grid:
 
 - For local execution:
   ```bash
   npm run smartui-local
   ```
 
-- For execution on LambdaTest Automation Cloud:
+- For execution on TestMu AI Automation Cloud:
   ```bash
   npm run smartui-cloud
   ```
 
-Visit our [documentation](https://www.lambdatest.com/support/docs/smartui-puppeteer-sdk/) for comprehensive SDK guides and tutorials.
+Visit our [documentation](https://www.testmuai.com/support/docs/smartui-puppeteer-sdk/) for comprehensive SDK guides and tutorials.
 
-## Testing with LambdaTest Hooks
+## Testing with TestMu AI Hooks
 
 ### Overview
 
-Like the SDK samples, these tests navigate to the LambdaTest homepage for title verification and visual regression via screenshot.
+Like the SDK samples, these tests navigate to the TestMu AI homepage for title verification and visual regression via screenshot.
 
 #### Setup
 
@@ -103,7 +103,7 @@ npm install
 
 #### Leveraging SmartUI Webhooks
 
-Use LambdaTest's webhook for seamless visual regression testing. Capture a screenshot with:
+Use TestMu AI's webhook for seamless visual regression testing. Capture a screenshot with:
 
 ```javascript
 await page.evaluate(() => {
@@ -119,7 +119,7 @@ await page.evaluate(() => {
 
 ### Running the Tests
 
-Deploy your tests on the LambdaTest Automation grid with:
+Deploy your tests on the TestMu AI Automation grid with:
 
 ```bash
 npm run single
@@ -127,4 +127,23 @@ npm run single
 
 ## Support and Assistance
 
-Our dedicated support team is available 24/7 to assist with any questions or challenges you may encounter. Contact us anytime at [support@lambdatest.com](mailto:support@lambdatest.com) for prompt and friendly support.
+Our dedicated support team is available 24/7 to assist with any questions or challenges you may encounter. Contact us anytime at [support@testmuai.com](mailto:support@testmuai.com) for prompt and friendly support.
+
+## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+
+Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
+
+**🔄 Our Rebrand Journey**
+
+We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+
+**✨ Specialties**
+
+- 🤖 AI-Native Test Execution (Formerly LambdaTest)
+- ⚡ Autonomous Test Automation
+- 🌐 Cross-Browser & Mobile Testing
+- 📊 Unified Quality Intelligence
+
+👉 Find [LambdaTest's New Home](https://www.testmuai.com/).

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ npm run single
 
 Our dedicated support team is available 24/7 to assist with any questions or challenges you may encounter. Contact us anytime at [support@testmuai.com](mailto:support@testmuai.com) for prompt and friendly support.
 
-## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+## 🚀 LambdaTest is Now TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
@@ -139,11 +139,15 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-**✨ Specialties**
-
-- 🤖 AI-Native Test Execution (Formerly LambdaTest)
-- ⚡ Autonomous Test Automation
-- 🌐 Cross-Browser & Mobile Testing
-- 📊 Unified Quality Intelligence
-
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
+**🔭 Explore TestMu AI**
+
+The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+
+- [KaneAI](https://www.testmuai.com/kane-ai/)
+- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
+- [HyperExecute](https://www.testmuai.com/hyperexecute/)
+- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
+- [Pricing](https://www.testmuai.com/pricing/)
+- [Documentation](https://www.testmuai.com/support/docs/)


### PR DESCRIPTION
## Summary

- Updated README to reflect LambdaTest to TestMu AI rebrand (January 2026)
- H1 heading updated to [Title] - TestMu AI (Formerly LambdaTest)
- Replaced LambdaTest with TestMu AI in all prose (skipping GitHub org URLs, package names, config file names, code blocks, and service subdomains)
- Community URL updated to community.testmuai.com
- YouTube channel updated to youtube.com/@TestMuAI
- Support email updated to support@testmuai.com
- Added rebrand section: LambdaTest is Now TestMu AI

Generated with Claude Code